### PR TITLE
Change test command to always fail on errors.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
             - "/usr/local/lib/R/site-library"
       - run:
           command: |
-            R -e 'devtools::check()'
+            R -e 'results <- devtools::check(); stopifnot(length(results$errors) == 0)'
       - store_artifacts:
           path: man/
           destination: man


### PR DESCRIPTION
Previously, the devtools::check command sometimes returned exit code 0 even though there were errors in tests, which caused the CI to accept change when it shouldn't.

This fixes the check by adding an explicit exception when there are errors.