### PR TITLE
Removed boxed codependence. Added sample id for each box.

### DIFF
--- a/R/box.R
+++ b/R/box.R
@@ -7,16 +7,21 @@
 #' @param title_side Side of a label. One of \code{c("top", "bottom", "top left", "top right", "bottom left", "bottom right")} if \code{ribbon = FALSE}, or one of \code{c("top left", "top right")} if \code{ribbon = TRUE}
 #' @param collapsible Should minimize button be added to label.
 #' @param width Width of the box.
+#' @param id ID of the box.
 #' @return A box that can be passed to \code{\link[semantic.dashboard]{dashboardBody}}
 #' @export
 #' @examples
 #' box(title = "Sample box", color = "blue", width = 11,
 #'     "This is a box content"
 #' )
-box <- function(..., title = NULL, color = "", ribbon = TRUE, title_side = "top right", collapsible = TRUE, width = 8) {
+box <- function(..., title = NULL, color = "", ribbon = TRUE, title_side = "top right", collapsible = TRUE, width = 8, id = NULL) {
   verify_value_allowed("color", c("", ALLOWED_COLORS))
   verify_value_allowed("title_side", if (ribbon) ALLOWED_BOX_SIDES_RIBBON else ALLOWED_BOX_SIDES_NONRIBBON)
-  box_id <- paste0("box_", sample(1:10000000, 1))
+  box_id <- if (!is.character(id)) {
+    random_id_generator()
+  } else {
+    id
+  }
   label <- if (!is.character(title)) {
     NULL
   } else {

--- a/R/box.R
+++ b/R/box.R
@@ -16,6 +16,7 @@
 box <- function(..., title = NULL, color = "", ribbon = TRUE, title_side = "top right", collapsible = TRUE, width = 8) {
   verify_value_allowed("color", c("", ALLOWED_COLORS))
   verify_value_allowed("title_side", if (ribbon) ALLOWED_BOX_SIDES_RIBBON else ALLOWED_BOX_SIDES_NONRIBBON)
+  box_id <- paste0("box_", sample(1:10000000, 1))
   label <- if (!is.character(title)) {
     NULL
   } else {
@@ -27,17 +28,17 @@ box <- function(..., title = NULL, color = "", ribbon = TRUE, title_side = "top 
     }
     shiny::div(class = title_class, minimize_button, title)
   }
-  js_script <- "$('.ui.accordion').accordion({
+  js_script <- paste0("$('#", box_id, "').accordion({
     onOpening: function() { $(this.context).find('.label .icon').removeClass('expand').addClass('minimize window'); },
     onClosing: function() { $(this.context).find('.label .icon').removeClass('minimize window').addClass('expand'); }
-  });"
+  });")
   column(width = width,
     shiny::div(class = paste("ui segment raised", color),
-      shiny::div(class = "ui accordion",
+      shiny::div(id = box_id, class = "ui accordion",
         shiny::div(class = "title", label),
         shiny::div(class = "content active", shiny::div(...))
       )
     ),
-    shiny::singleton(shiny::tags$script(paste0("$(document).ready(function() { ", js_script, " })")))
+    if (collapsible) shiny::singleton(shiny::tags$script(paste0("$(document).ready(function() { ", js_script, " })")))
   )
 }

--- a/R/box.R
+++ b/R/box.R
@@ -18,7 +18,7 @@ box <- function(..., title = NULL, color = "", ribbon = TRUE, title_side = "top 
   verify_value_allowed("color", c("", ALLOWED_COLORS))
   verify_value_allowed("title_side", if (ribbon) ALLOWED_BOX_SIDES_RIBBON else ALLOWED_BOX_SIDES_NONRIBBON)
   box_id <- if (!is.character(id)) {
-    random_id_generator()
+    paste0("box_", random_id_generator())
   } else {
     id
   }

--- a/R/tab_box.R
+++ b/R/tab_box.R
@@ -7,6 +7,7 @@
 #' @param title_side Side of a label. One of \code{c("top", "bottom", "top left", "top right", "bottom left", "bottom right")} if \code{ribbon = FALSE}, or one of \code{c("top left", "top right")} if \code{ribbon = TRUE}
 #' @param collapsible Should minimize button be added to label.
 #' @param width Width of the box.
+#' @param id ID of the box.
 #' @return A box that can be passed to \code{\link[semantic.dashboard]{dashboardBody}}
 #' @export
 #' @examples
@@ -16,7 +17,7 @@
 #'          list(menu = "Second Tab", content = "This is second tab")
 #'        ))
 tab_box <- function(tabs, title = NULL, color = "", ribbon = TRUE,
-                    title_side = "top right", collapsible = TRUE, width = 8) {
+                    title_side = "top right", collapsible = TRUE, width = 8, id = NULL) {
   box(shiny.semantic::tabset(tabs), title = title, color = color, ribbon = ribbon, title_side = title_side,
       collapsible = collapsible, width = width)
 }

--- a/R/tab_box.R
+++ b/R/tab_box.R
@@ -19,7 +19,7 @@
 tab_box <- function(tabs, title = NULL, color = "", ribbon = TRUE,
                     title_side = "top right", collapsible = TRUE, width = 8, id = NULL) {
   box(shiny.semantic::tabset(tabs), title = title, color = color, ribbon = ribbon, title_side = title_side,
-      collapsible = collapsible, width = width)
+      collapsible = collapsible, width = width, id = id)
 }
 
 #' @describeIn tab_box Create a tab box (alias for \code{tab_box} for compatibility with \code{shinydashboard})

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,5 @@
 # Verify that given variable is in the list of allowed values.
-verify_value_allowed <- function(variable, values){
+verify_value_allowed <- function(variable, values) {
   var <- get(variable, envir = parent.frame())
   if (!(var %in% values)){
     warning(paste(paste0("'", variable, "'"),
@@ -17,4 +17,9 @@ get_inverted_class <- function(inverted) {
 interlace_dividers <- function(elements) {
   dividers <- lapply(1:length(elements), function(i) shiny::tags$div(class = "divider"))
   utils::head(c(rbind(elements, dividers)), -1) # Skips last divider with head.
+}
+
+# Random ID generator
+random_id_generator <- function(values = 0:9, id_length = 30) {
+  paste0(sample(values, id_length, TRUE), collapse = "")
 }

--- a/examples/app.R
+++ b/examples/app.R
@@ -27,6 +27,7 @@ ui <- dashboardPage(
                                 label = "Select second variable", selected = "cyl"),
                     plotlyOutput("mtcars_plot")),
                 tabBox(title = "Sample box", color = "blue", width = 5,
+                       collapsible = FALSE,
                        tabs = list(
                          list(menu = "First Tab", content = "Some text..."),
                          list(menu = "Second Tab", content = plotlyOutput("mtcars_plot2"))

--- a/man/box.Rd
+++ b/man/box.Rd
@@ -5,7 +5,7 @@
 \title{Create a box.}
 \usage{
 box(..., title = NULL, color = "", ribbon = TRUE,
-  title_side = "top right", collapsible = TRUE, width = 8)
+  title_side = "top right", collapsible = TRUE, width = 8, id = NULL)
 }
 \arguments{
 \item{...}{UI elements to include within the box.}
@@ -21,6 +21,8 @@ box(..., title = NULL, color = "", ribbon = TRUE,
 \item{collapsible}{Should minimize button be added to label.}
 
 \item{width}{Width of the box.}
+
+\item{id}{ID of the box.}
 }
 \value{
 A box that can be passed to \code{\link[semantic.dashboard]{dashboardBody}}

--- a/man/tab_box.Rd
+++ b/man/tab_box.Rd
@@ -6,10 +6,10 @@
 \title{Create a tab box.}
 \usage{
 tab_box(tabs, title = NULL, color = "", ribbon = TRUE,
-  title_side = "top right", collapsible = TRUE, width = 8)
+  title_side = "top right", collapsible = TRUE, width = 8, id = NULL)
 
 tabBox(tabs, title = NULL, color = "", ribbon = TRUE,
-  title_side = "top right", collapsible = TRUE, width = 8)
+  title_side = "top right", collapsible = TRUE, width = 8, id = NULL)
 }
 \arguments{
 \item{tabs}{Tabs to include within the box.}
@@ -25,6 +25,8 @@ tabBox(tabs, title = NULL, color = "", ribbon = TRUE,
 \item{collapsible}{Should minimize button be added to label.}
 
 \item{width}{Width of the box.}
+
+\item{id}{ID of the box.}
 }
 \value{
 A box that can be passed to \code{\link[semantic.dashboard]{dashboardBody}}


### PR DESCRIPTION
Closes #66

The problem was that, if at least one box had a collapse button then javascript would work on every box in app. Fixed by adding unique id for each `box`.