### PR TITLE
Force width values for semantic classes in page body.

### DIFF
--- a/R/semantic_dashboard.R
+++ b/R/semantic_dashboard.R
@@ -145,6 +145,7 @@ dashboardSidebar <- dashboard_sidebar
 #' }
 dashboard_body <- function(...){
   shiny::div(class = "pusher container", style = "min-height: 100vh; margin-left: 0",
+             shiny::tags$style(HTML(".tab-content, .ui.grid.container, .container {width:100%!important}")),
              shiny::div(class = "ui segment", style = "min-height: 100vh;",
                         shiny::tags$div(class = "ui stackable container grid", ...)),
              body_js)


### PR DESCRIPTION
Fix for #125

Removes the static max value added by semantic.ui to container elements. This was forcing container elements to have, at most, 1127px width. (See [https://semantic-ui.com/elements/container.html](url) for more information.)

This change overwrites the default semantic.ui rule to always make the container as wide as the parent element, removing gutter space in all screen sizes:

![Screenshot from 2019-09-30 16-12-10](https://user-images.githubusercontent.com/44022548/65887431-32e95080-e39e-11e9-99ee-7753b0a38b66.png)
![Screenshot from 2019-09-30 16-13-28](https://user-images.githubusercontent.com/44022548/65887438-354baa80-e39e-11e9-8d8f-543df3ba7c9d.png)

