### PR TITLE
new way of supressing bootstrap

### DIFF
--- a/R/semantic_dashboard.R
+++ b/R/semantic_dashboard.R
@@ -169,13 +169,16 @@ dashboard_body <- function(...){
 dashboardBody <- dashboard_body
 
 #' Create a dashboard.
-#' @description Create a page with menu item sidebar and body containing tabs and other additional elements.
+#' @description Create a page with menu item sidebar and body containing tabs
+#' and other additional elements.
 #' @param  header Header of a dashboard.
 #' @param  sidebar Sidebar of a dashboard.
 #' @param  body Body of a dashboard.
 #' @param  title Title of a dashboard.
 #' @param  theme Theme name or path TODO list of themes
-#' @param suppress_bootstrap There are some conflicts in CSS styles between SemanticUI and Bootstrap. For the time being it's better to suppress Bootstrap. If \code{TRUE} bootstrap dependency from \code{shiny} will be disabled.
+#' @param suppress_bootstrap There are some conflicts in CSS styles between
+#' SemanticUI and Bootstrap. For the time being it's better to suppress Bootstrap.
+#' If \code{TRUE} bootstrap dependency from \code{shiny} will be disabled.
 #' @return Dashboard.
 #' @export
 #' @examples
@@ -202,10 +205,9 @@ dashboardBody <- dashboard_body
 #' }
 dashboard_page <- function(header, sidebar, body, title = "",
                            suppress_bootstrap = TRUE, theme = NULL) {
-  # TODO: Remove this line when it is added to semanticPage()
-  if (suppress_bootstrap) shiny::suppressDependencies("bootstrap")
   if (is.null(sidebar)) header$children[[1]] <- NULL
   shiny.semantic::semanticPage(header, sidebar, body, title = title,
+                               suppress_bootstrap = suppress_bootstrap,
                                theme = theme, get_dashboard_dependencies(),
                                shiny::tags$script(glue("sidebar_observer('{sidebar$attribs$id}')")))
 }


### PR DESCRIPTION
# new way of supressing bootstrap

Through semanticPage this time.
Complementary PR here: https://github.com/Appsilon/shiny.semantic/pull/181