### PR TITLE
Use "ui content" instead of "ui segment" in dashboard body. Related to #147

### DIFF
--- a/R/semantic_dashboard.R
+++ b/R/semantic_dashboard.R
@@ -160,7 +160,7 @@ dashboardSidebar <- dashboard_sidebar
 dashboard_body <- function(...){
   shiny::div(class = "pusher container", style = "min-height: 100vh; margin-left: 0",
              shiny::tags$style(HTML(".tab-content, .ui.grid.container, .container {width:100%!important}")),
-             shiny::div(class = "ui segment", style = "min-height: 100vh;",
+             shiny::div(class = "ui content", style = "min-height: 100vh;",
                         shiny::tags$div(class = "ui stackable container grid", ...)))
 }
 


### PR DESCRIPTION
# Fix theming problem with dashboard_body()

As described in #147, using a dark theme doesn't work well. For example, the headers remain white on white.

This fixes this specific issue by using `content` instead of `segment` for the dashboard body.

Light theme:

![image](https://user-images.githubusercontent.com/479998/97979813-b9553a80-1dc7-11eb-88f6-cb30ebaec958.png)

Dark theme (cyborg):

![image](https://user-images.githubusercontent.com/479998/97979866-d0942800-1dc7-11eb-88d3-fb41753331a1.png)


Test code:

```r
library(shiny)
library(semantic.dashboard)

ui <- dashboardPage(
  theme = "cyborg",
  dashboardHeader(),
  dashboardSidebar(side = "left", size = "thin",
                   sidebarMenu(
                     menuItem(tabName = "tab1", "Tab 1"),
                     menuItem(tabName = "tab2", "Tab 2"))),
  dashboardBody(tabItems(
    tabItem(tabName = "tab1", p("Tab 1")),
    tabItem(tabName = "tab2", p("Tab 2"))))
)

server <- function(input, output) {
}

shinyApp(ui, server)
```

