### PR TITLE
CRAN notes fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,6 @@ Authors@R: c(person("Filip", "Stachura", email = "filip@appsilon.com", role = "a
 Description: It offers functions for creating dashboard with Fomantic UI. 
 BugReports: https://github.com/Appsilon/semantic.dashboard/issues
 Encoding: UTF-8
-LazyData: TRUE
 License: MIT + file LICENSE
 Imports:
     utils,
@@ -25,5 +24,8 @@ Suggests:
     testthat,
     lintr,
     shinydashboard,
-    covr
-RoxygenNote: 7.1.1
+    covr,
+    knitr
+RoxygenNote: 7.1.2
+VignetteBuilder:
+    knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Suggests:
     lintr,
     shinydashboard,
     covr,
-    knitr
+    knitr,
+    rmarkdown
 RoxygenNote: 7.1.2
 VignetteBuilder:
     knitr

--- a/vignettes/intro.Rmd
+++ b/vignettes/intro.Rmd
@@ -28,9 +28,9 @@ Dashboards provide a solution. They allow the developer to intuitively structure
 
 # Why Semantic Dashboard?
 
-Semantic Dashboard offers an alternative look of your dashboard based on the [Fomantic UI](fomantic-ui.com/). Historically, we built this package around *Semantic UI*
+Semantic Dashboard offers an alternative look of your dashboard based on the [Fomantic UI](https://fomantic-ui.com/). Historically, we built this package around *Semantic UI*
 library, but it got deprecated and now (since December 2019) we base on the well-supported
-and maintained community fork called [Fomantic UI](fomantic-ui.com/).
+and maintained community fork called [Fomantic UI](https://fomantic-ui.com/).
 
 It relies and uses components from the mother package [shiny.semantic](https://github.com/Appsilon/shiny.semantic/).
 


### PR DESCRIPTION
Fix CRAN notes:
- Add vignette builder to DESRIPTION
- Remove LazyData field from DESCRIPTION
- Add `rmarkdown` to Suggests as it's required by a vignette
- Fix invalid URL's in vignette